### PR TITLE
Passing branch filter on AppVeyor request

### DIFF
--- a/AppVeyorTestAnalyzer/AppVeyorClient.cs
+++ b/AppVeyorTestAnalyzer/AppVeyorClient.cs
@@ -44,10 +44,10 @@ namespace AppVeyor
             return result;
         }
 
-        public async Task<HistoryResponse> GetBuildHistoryAsync(Project project, int? startBuildId = null)
+        public async Task<HistoryResponse> GetBuildHistoryAsync(Project project, string branch, int? startBuildId = null)
         {
             // GET /api/projects/appsvc/azure-webjobs-sdk-script-y8o14/history?recordsNumber=10&startbuildId=9817916
-            var url = $"/projects/{project.accountName}/{project.slug}/history?recordsNumber=50";
+            var url = $"/projects/{project.accountName}/{project.slug}/history?recordsNumber=50&branch={branch}";
             if (startBuildId != null)
             {
                 url += "&startbuildId=" + startBuildId;

--- a/AppVeyorTestAnalyzer/Program.cs
+++ b/AppVeyorTestAnalyzer/Program.cs
@@ -27,6 +27,7 @@ namespace AppVeyorTestAnalyzer
             DateTimeOffset startDate = endDate.AddDays(-daysToScan);
             await Work(client, "azure-functions-host", "v1.x", startDate, endDate);
             await Work(client, "azure-webjobs-sdk", "v2.x", startDate, endDate);
+            await Work(client, "azure-functions-host", "dev", startDate, endDate);
 
             Console.Write("Press any key to exit...");
             Console.ReadKey();
@@ -75,7 +76,7 @@ namespace AppVeyorTestAnalyzer
             while (true)
             {
                 Console.Write(".");
-                var history = await client.GetBuildHistoryAsync(project, lastBuildId);
+                var history = await client.GetBuildHistoryAsync(project, branch, lastBuildId + 1);
 
                 if (history.builds.Length == 0)
                 {


### PR DESCRIPTION
Small fixes to filter the branch and make sure we don't end up in an infinite loop if a single build is found.